### PR TITLE
Fix invalid XML declaration in getConfigXML() (#71)

### DIFF
--- a/software/esp-firmware/wifiHandling.cpp
+++ b/software/esp-firmware/wifiHandling.cpp
@@ -654,7 +654,7 @@ void getConfigXML()
 //     char * hostName = strdup(throttleName);
 
    /* collect response */      
-   String resp = String("<?XML version=\"1.0\" encoding=\"UTF?8\"?>\r\n")
+   String resp = String("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n")
                
           + "<wiFred>\r\n"
                   + "<structurVersion value=\"1\"/>\r\n"


### PR DESCRIPTION
Fixes the malformed XML declaration emitted by `getConfigXML()` in
`software/esp-firmware/wifiHandling.cpp`, reported in #71.

The current declaration has two problems:

```c
String resp = String("<?XML version=\"1.0\" encoding=\"UTF?8\"?>\r\n")
```

1. `<?XML` (uppercase) is not a valid XML declaration. Per W3C XML 1.0
   §2.8 the literal is lowercase `<?xml`, and §2.6 explicitly reserves any
   case variation of "xml" as a processing-instruction target — so the
   output is neither a valid declaration nor a valid PI, and strict parsers
   (e.g. .NET `XDocument.Parse`) reject it.
2. `encoding="UTF?8"` is not a valid encoding name — the `-` appears to have
   been corrupted into a `?`. It should be `UTF-8`.

This changes only that one string literal to a spec-compliant declaration:

```c
String resp = String("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n")
```

No other behavior changes; the element/attribute structure is untouched.

I understand from #71 that you don't maintain the XML config feature — this
is offered purely as a minimal correctness fix so the output parses with
standards-compliant XML parsers without a client-side workaround. Feel free
to take or leave it.
